### PR TITLE
Easy pointer fix

### DIFF
--- a/src/main/java/com/yammer/dropwizard/apidocs/ServiceDoclet.java
+++ b/src/main/java/com/yammer/dropwizard/apidocs/ServiceDoclet.java
@@ -53,7 +53,7 @@ public class ServiceDoclet {
                     }
 
                     apiBuilder.add(new Api(apiPath, classDoc.getRawCommentText(), methodBuilder));
-                    builder.add(new ResourceListingAPI("/apidocs/descriptors/" + classDoc.name() + ".{format}",
+                    builder.add(new ResourceListingAPI("/apidocs/" + classDoc.name() + ".{format}",
                                                        classDoc.getRawCommentText()));
 
                     File classFile = new File(parameters.getOutput(), classDoc.name() + ".json");


### PR DESCRIPTION
Duct tape solution to point service.json at the root dir for api descriptors. Longer term solution would be to generate those files in the correct spot.
