### PR TITLE
Adds default jax-rs @ exclusions and doclet option `excludeAnnotationClasses'

### DIFF
--- a/src/main/java/com/yammer/dropwizard/apidocs/JavaDocParameters.java
+++ b/src/main/java/com/yammer/dropwizard/apidocs/JavaDocParameters.java
@@ -1,12 +1,16 @@
 package com.yammer.dropwizard.apidocs;
 
+import java.util.Arrays;
+
 import java.io.File;
+import java.util.List;
 
 public class JavaDocParameters {
     private File output;
     private String docBasePath;
     private String apiBasePath;
     private String apiVersion;
+    private List<String> excludeAnnotationClasses;
 
     private JavaDocParameters() {
     }
@@ -27,6 +31,27 @@ public class JavaDocParameters {
 		return apiVersion;
 	}
 
+	public List<String> getExcludeAnnotationClasses() {
+		return excludeAnnotationClasses;
+	}
+
+	/**
+	 * Parse javadoc doclet options
+	 *
+	 * @param options
+	 * <p> 
+	 *   Example: 
+	 *   <pre>
+	 *   -apiVersion 1 
+	 *   -docBasePath http://localhost:8080 
+	 *   -apiBasePath http://localhost:8080 
+	 *   -excludeAnnotationClasses com.example.Context com.example.Auth
+	 *   </pre>
+	 *   </p>
+	 * @return parsed javadoc parameters
+	 *
+	 * @see com.sun.javadoc.RootDoc#options
+	 */
 	public static JavaDocParameters parse(String[][] options) {
         JavaDocParameters parameters = new JavaDocParameters();
 
@@ -39,6 +64,8 @@ public class JavaDocParameters {
             	parameters.apiBasePath = option[1];
             } else if(option[0].equals("-apiVersion")) {
             	parameters.apiVersion = option[1];
+            } else if(option[0].equals("-excludeAnnotationClasses")) {
+            	parameters.excludeAnnotationClasses = Arrays.asList(Arrays.copyOfRange(option, 1, option.length));
             }
         }
 


### PR DESCRIPTION
Method parameters with jax-rs annotations `@Context` and `@HeaderParam`
are excluded from API docs. In addition the doclet option
`excludeAnnotationClasses` takes space-separated fully qualified class
names for other method params to exclude.

e.g. this resource with header-authenticated `Bar` injected

```
@GET
@Path("/foos")
public List<Foo> barsFoos(@Auth Bar bar)
```

Together with this javadoc plugin fragment:

```
<additionalparam>-excludeAnnotationClasses com.yammer.dropwizard.Auth</additionalparam>
```

I'm not entirely enthusiastic about the option name `excludeAnnotationClasses`, if there is a better suggestion (`exclude` ?) I can change it.

Also, I'm not sure if this is the way to go anyway. The example swagger docs still have the non-param parameter in the implementation notes, something similar I suppose could be done here so we don't lose that information:
![image](https://f.cloud.github.com/assets/42975/59446/f2bde918-5bc7-11e2-974e-7d12f3a4b2f0.png)
