### PR TITLE
Don't exclude POST parameter with unrecognised annotations

### DIFF
--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/HttpMethod.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/HttpMethod.java
@@ -1,0 +1,35 @@
+package com.hypnoticocelot.jaxrs.doclet;
+
+import com.sun.javadoc.AnnotationDesc;
+import com.sun.javadoc.MethodDoc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum HttpMethod {
+    GET("javax.ws.rs.GET"),
+    PUT("javax.ws.rs.PUT"),
+    POST("javax.ws.rs.POST"),
+    DELETE("javax.ws.rs.DELETE");
+
+    private final String canonicalClassname;
+
+    private HttpMethod(String canonicalClassname) {
+        this.canonicalClassname = canonicalClassname;
+    }
+
+    public static HttpMethod fromMethod(MethodDoc method) {
+        List<String> typeNames = new ArrayList<String>();
+        for (AnnotationDesc annotation : method.annotations()) {
+            typeNames.add(annotation.annotationType().qualifiedTypeName());
+        }
+        HttpMethod found = null;
+        for (HttpMethod value : HttpMethod.values()) {
+            if (typeNames.contains(value.canonicalClassname)) {
+                found = value;
+                break;
+            }
+        }
+        return found;
+    }
+}

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/Method.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/Method.java
@@ -3,7 +3,7 @@ package com.hypnoticocelot.jaxrs.doclet;
 import java.util.List;
 
 public class Method {
-    private String method;
+    private HttpMethod method;
     private String methodName;
     private List<ApiParameter> apiParameters;
     private String firstSentence;
@@ -15,7 +15,7 @@ public class Method {
     private Method() {
     }
 
-    public Method(String method, String methodName, String path, List<ApiParameter> apiParameters, String firstSentence, String comment, String returnType) {
+    public Method(HttpMethod method, String methodName, String path, List<ApiParameter> apiParameters, String firstSentence, String comment, String returnType) {
         this.method = method;
         this.methodName = methodName;
         this.path = path;
@@ -25,7 +25,7 @@ public class Method {
         this.returnType = returnType;
     }
 
-    public String getMethod() {
+    public HttpMethod getMethod() {
         return method;
     }
 

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/Operation.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/Operation.java
@@ -3,7 +3,7 @@ package com.hypnoticocelot.jaxrs.doclet;
 import java.util.List;
 
 public class Operation {
-    private String httpMethod;
+    private HttpMethod httpMethod;
     private String nickname;
     private String responseClass; // void, primitive, complex or a container
     private List<ApiParameter> parameters;
@@ -14,7 +14,7 @@ public class Operation {
     private Operation() {
     }
 
-    public Operation(String httpMethod, String nickname, String responseClass, List<ApiParameter> parameters, String summary, String notes) {
+    public Operation(HttpMethod httpMethod, String nickname, String responseClass, List<ApiParameter> parameters, String summary, String notes) {
         this.httpMethod = httpMethod;
         this.nickname = nickname;
         this.responseClass = responseClass;
@@ -23,7 +23,7 @@ public class Operation {
         this.notes = notes;
     }
 
-    public String getHttpMethod() {
+    public HttpMethod getHttpMethod() {
         return httpMethod;
     }
 

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/ServiceDoclet.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/ServiceDoclet.java
@@ -347,10 +347,7 @@ public class ServiceDoclet {
             return true;
         }
 
-        if (allAnnotations.isEmpty() || httpMethod == HttpMethod.POST) {
-            return paramTypeOf(parameter).equalsIgnoreCase("body");
-        }
-        return false;
+        return (allAnnotations.isEmpty() || httpMethod == HttpMethod.POST);
     }
 
     /**

--- a/jaxrs-doclet/src/test/resources/fixtures/sample/Service.java
+++ b/jaxrs-doclet/src/test/resources/fixtures/sample/Service.java
@@ -1,14 +1,22 @@
 package fixtures.sample;
 
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 
 @Path("/foo")
 public class Service {
     @GET
     public String sayHello(@QueryParam("name") @DefaultValue("World") String name) {
         return "Hello, " + name + "!";
+    }
+
+    @POST
+    public int createSpeech(String speech) {
+        return speech.hashCode();
+    }
+
+    @Path("/annotated")
+    @POST
+    public int createSpeechWithAnnotatedPayload(@Deprecated String speech) {
+        return speech.hashCode();
     }
 }

--- a/jaxrs-doclet/src/test/resources/fixtures/sample/foo.json
+++ b/jaxrs-doclet/src/test/resources/fixtures/sample/foo.json
@@ -20,6 +20,42 @@
                     ],
                     "summary": "",
                     "notes": ""
+                },
+                {
+                    "httpMethod": "POST",
+                    "nickname": "createSpeech",
+                    "responseClass": "int",
+                    "parameters": [
+                        {
+                            "paramType": "body",
+                            "name": "speech",
+                            "description": null,
+                            "dataType": "string"
+                        }
+                    ],
+                    "summary": "",
+                    "notes": ""
+                }
+            ]
+        },
+        {
+            "path": "/foo/annotated",
+            "description": "",
+            "operations": [
+                {
+                    "httpMethod": "POST",
+                    "nickname": "createSpeechWithAnnotatedPayload",
+                    "responseClass": "int",
+                    "parameters": [
+                        {
+                            "paramType": "body",
+                            "name": "speech",
+                            "description": null,
+                            "dataType": "string"
+                        }
+                    ],
+                    "summary": "",
+                    "notes": ""
                 }
             ]
         }


### PR DESCRIPTION
If the POST payload has any kind of annotation, it is not picked up by the doclet, leaving the payload argument undocumented (and therefore untestable in swagger).

We discovered this behaviour when trying to annotate a payload with `@javax.validation.constraints.NotNull`, but it behaves the same for any generic annotation, like `@Deprecated` as well.

---

I had to restructure the `shouldIncludeParameter` method a bit to make this work. If the parameter:
- has an excluded annotation, return `false`
- has an allowed JAX-RS annotation, return `true`
- has no annotations or is a POST method, return `true`
- otherwise return `false`

Could you please confirm that this is the expected behaviour?

Cheers,
David
