### PR TITLE
Treat java.lang.Object as a primitive.

### DIFF
--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiModelParser.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiModelParser.java
@@ -30,8 +30,9 @@ public class ApiModelParser {
     private void parseModel(Type type) {
         boolean isPrimitive = /* type.isPrimitive()? || */ AnnotationHelper.isPrimitive(type);
         boolean isJavaxType = type.qualifiedTypeName().startsWith("javax.");
+        boolean isBaseObject = type.qualifiedTypeName().equals("java.lang.Object");
         ClassDoc classDoc = type.asClassDoc();
-        if (isPrimitive || isJavaxType || classDoc == null || alreadyStoredType(type)) {
+        if (isPrimitive || isJavaxType || isBaseObject || classDoc == null || alreadyStoredType(type)) {
             return;
         }
 

--- a/jaxrs-doclet/src/test/java/com/hypnoticocelot/jaxrs/doclet/apidocs/ObjectTest.java
+++ b/jaxrs-doclet/src/test/java/com/hypnoticocelot/jaxrs/doclet/apidocs/ObjectTest.java
@@ -1,0 +1,45 @@
+package com.hypnoticocelot.jaxrs.doclet.apidocs;
+
+import com.hypnoticocelot.jaxrs.doclet.DocletOptions;
+import com.hypnoticocelot.jaxrs.doclet.Recorder;
+import com.hypnoticocelot.jaxrs.doclet.model.ApiDeclaration;
+import com.hypnoticocelot.jaxrs.doclet.parser.JaxRsAnnotationParser;
+import com.sun.javadoc.RootDoc;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.hypnoticocelot.jaxrs.doclet.apidocs.FixtureLoader.loadFixture;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ObjectTest {
+
+    private Recorder recorderMock;
+    private DocletOptions options;
+
+    @Before
+    public void setup() {
+        recorderMock = mock(Recorder.class);
+        options = new DocletOptions().setRecorder(recorderMock);
+    }
+
+    @Test
+    public void testStart() throws IOException {
+        final RootDoc rootDoc = RootDocLoader.fromPath("src/test/resources", "fixtures.object");
+        new JaxRsAnnotationParser(options, rootDoc).run();
+
+        List<String> primitives = Arrays.asList("object");
+        for (String primitive : primitives) {
+            final ApiDeclaration api = loadFixture("/fixtures/object/object.json", ApiDeclaration.class);
+            verify(recorderMock).record(any(File.class), eq(api));
+        }
+    }
+
+}

--- a/jaxrs-doclet/src/test/resources/fixtures/object/ObjectResource.java
+++ b/jaxrs-doclet/src/test/resources/fixtures/object/ObjectResource.java
@@ -1,0 +1,13 @@
+package fixtures.object;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+
+@Path("/objects")
+public class ObjectResource {	
+	@GET
+	public Object get() {
+		return new Object();
+	}
+}

--- a/jaxrs-doclet/src/test/resources/fixtures/object/object.json
+++ b/jaxrs-doclet/src/test/resources/fixtures/object/object.json
@@ -1,0 +1,19 @@
+{
+    "apiVersion": "0",
+    "swaggerVersion": "1.1",
+    "basePath": "http://localhost:8080",
+    "resourcePath": "/objects",
+    "apis": [
+        {
+            "path": "/objects",
+            "description": "",
+            "operations": [
+                {
+                    "httpMethod": "GET",
+                    "nickname": "get",
+                    "responseClass": "object"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
We need to use Object in our Dropwizard API for some dynamic responses.  The model parser introspects deeply into java.lang.Object and generates are very large json file for that API.  The swagger UI ends up with errors when parsing the resulting file.

This change treats java.lang.Object like a primitive and just stops recursing when encountered.
