### PR TITLE
Error response javadoc @tag

### DIFF
--- a/jaxrs-doclet-sample-dropwizard/pom.xml
+++ b/jaxrs-doclet-sample-dropwizard/pom.xml
@@ -53,7 +53,7 @@
                             </docletArtifact>
                             <reportOutputDirectory>${project.build.outputDirectory}</reportOutputDirectory>
                             <useStandardDocletOptions>false</useStandardDocletOptions>
-                            <additionalparam>-apiVersion 1 -docBasePath /apidocs/ -apiBasePath /</additionalparam>
+                            <additionalparam>-apiVersion 1 -docBasePath /apidocs/ -apiBasePath / -errorTags @status</additionalparam>
                         </configuration>
                         <goals>
                             <goal>javadoc</goal>

--- a/jaxrs-doclet-sample-dropwizard/src/main/java/com/hypnoticocelot/jaxrs/doclet/sample/resources/AuthResource.java
+++ b/jaxrs-doclet-sample-dropwizard/src/main/java/com/hypnoticocelot/jaxrs/doclet/sample/resources/AuthResource.java
@@ -7,6 +7,9 @@ import javax.ws.rs.Path;
 
 @Path("/Auth")
 public class AuthResource {
+    /**
+     * @status 404 not found
+     */
     @GET
     public String authorize(@Auth String user) {
         return "USER = " + user;

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/DocletOptions.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/DocletOptions.java
@@ -20,6 +20,7 @@ public class DocletOptions {
     private String apiBasePath = "http://localhost:8080";
     private String apiVersion = "0";
     private List<String> excludeAnnotationClasses;
+    private List<String> errorTags;
     private boolean parseModels = true;
     private Recorder recorder = new ObjectMapperRecorder();
     private Translator translator;
@@ -28,6 +29,9 @@ public class DocletOptions {
         excludeAnnotationClasses = new ArrayList<String>();
         excludeAnnotationClasses.add("javax.ws.rs.HeaderParam");
         excludeAnnotationClasses.add("javax.ws.rs.core.Context");
+        errorTags = new ArrayList<String>();
+        errorTags.add("errorResponse");   // swagger 1.1
+        errorTags.add("responseMessage"); // swagger 1.2
         translator = new FirstNotNullTranslator()
                 .addNext(new AnnotationAwareTranslator()
                         .ignore("javax.xml.bind.annotation.XmlTransient")
@@ -58,6 +62,8 @@ public class DocletOptions {
                 parsedOptions.excludeAnnotationClasses.addAll(asList(copyOfRange(option, 1, option.length)));
             } else if (option[0].equals("-disableModels")) {
                 parsedOptions.parseModels = false;
+            } else if (option[0].equals("-errorTags")) {
+                parsedOptions.errorTags.addAll(asList(copyOfRange(option, 1, option.length)));;
             }
         }
         return parsedOptions;
@@ -81,6 +87,10 @@ public class DocletOptions {
 
     public List<String> getExcludeAnnotationClasses() {
         return excludeAnnotationClasses;
+    }
+    
+    public List<String> getErrorTags() {
+        return errorTags;
     }
 
     public boolean isParseModels() {

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/ServiceDoclet.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/ServiceDoclet.java
@@ -41,6 +41,7 @@ public class ServiceDoclet {
         options.put("-apiVersion", 2);
         options.put("-excludeAnnotationClasses", 2);
         options.put("-disableModels", 1);
+        options.put("-errorTags", 2);
 
         Integer value = options.get(option);
         if (value != null) {

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/model/ApiResponseMessage.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/model/ApiResponseMessage.java
@@ -1,0 +1,50 @@
+package com.hypnoticocelot.jaxrs.doclet.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+public class ApiResponseMessage {
+
+    private int code;
+    
+    @JsonProperty("reason") // swagger 1.1 name
+    private String message; // swagger 1.2 name
+    
+    @SuppressWarnings("unused")
+    private ApiResponseMessage() {
+    }
+
+    public ApiResponseMessage(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+    
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApiResponseMessage that = (ApiResponseMessage) o;
+        return Objects.equal(code, that.code)
+                && Objects.equal(message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(code, message);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("code", code)
+                .add("message", message)
+                .toString();
+    }}

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/model/Method.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/model/Method.java
@@ -8,6 +8,7 @@ public class Method {
     private HttpMethod method;
     private String methodName;
     private List<ApiParameter> apiParameters;
+    private List<ApiResponseMessage> responseMessages;
     private String firstSentence;
     private String comment;
     private String returnType;
@@ -17,11 +18,12 @@ public class Method {
     private Method() {
     }
 
-    public Method(HttpMethod method, String methodName, String path, List<ApiParameter> apiParameters, String firstSentence, String comment, String returnType) {
+    public Method(HttpMethod method, String methodName, String path, List<ApiParameter> apiParameters, List<ApiResponseMessage> responseMessages, String firstSentence, String comment, String returnType) {
         this.method = method;
         this.methodName = methodName;
         this.path = path;
         this.apiParameters = apiParameters;
+        this.responseMessages = responseMessages;
         this.firstSentence = firstSentence;
         this.comment = comment;
         this.returnType = returnType;
@@ -41,6 +43,10 @@ public class Method {
 
     public List<ApiParameter> getParameters() {
         return apiParameters;
+    }
+    
+    public List<ApiResponseMessage> getResponseMessages() {
+        return responseMessages;
     }
 
     public String getFirstSentence() {
@@ -67,6 +73,7 @@ public class Method {
         return Objects.equal(method, that.method)
                 && Objects.equal(methodName, that.methodName)
                 && Objects.equal(apiParameters, that.apiParameters)
+                && Objects.equal(responseMessages, that.responseMessages)
                 && Objects.equal(firstSentence, that.firstSentence)
                 && Objects.equal(comment, that.comment)
                 && Objects.equal(returnType, that.returnType)
@@ -75,7 +82,7 @@ public class Method {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(method, methodName, apiParameters, firstSentence, comment, returnType, path);
+        return Objects.hashCode(method, methodName, apiParameters, responseMessages, firstSentence, comment, returnType, path);
     }
 
     @Override
@@ -84,6 +91,7 @@ public class Method {
                 .add("method", method)
                 .add("methodName", methodName)
                 .add("apiParameters", apiParameters)
+                .add("responseMessages", responseMessages)
                 .add("firstSentence", firstSentence)
                 .add("comment", comment)
                 .add("returnType", returnType)

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/model/Operation.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/model/Operation.java
@@ -1,5 +1,6 @@
 package com.hypnoticocelot.jaxrs.doclet.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.hypnoticocelot.jaxrs.doclet.parser.AnnotationHelper;
 
@@ -16,6 +17,9 @@ public class Operation {
     private String summary; // cap at 60 characters for readability in the UI
     private String notes;
 
+    @JsonProperty("errorResponses")                    // swagger 1.1 name
+    private List<ApiResponseMessage> responseMessages; // swagger 1.2 name
+
     @SuppressWarnings("unused")
     private Operation() {
     }
@@ -25,6 +29,7 @@ public class Operation {
         this.nickname = emptyToNull(method.getMethodName());
         this.responseClass = emptyToNull(AnnotationHelper.typeOf(method.getReturnType()));
         this.parameters = method.getParameters().isEmpty() ? null : method.getParameters();
+        this.responseMessages = method.getResponseMessages().isEmpty() ? null : method.getResponseMessages();
         this.summary = emptyToNull(method.getFirstSentence());
         this.notes = emptyToNull(method.getComment());
     }
@@ -44,6 +49,10 @@ public class Operation {
     public List<ApiParameter> getParameters() {
         return parameters;
     }
+    
+    public List<ApiResponseMessage> getResponseMessages() {
+        return responseMessages;
+    }
 
     public String getSummary() {
         return summary;
@@ -62,13 +71,14 @@ public class Operation {
                 && Objects.equal(nickname, that.nickname)
                 && Objects.equal(responseClass, that.responseClass)
                 && Objects.equal(parameters, that.parameters)
+                && Objects.equal(responseMessages, that.responseMessages)
                 && Objects.equal(summary, that.summary)
                 && Objects.equal(notes, that.notes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(httpMethod, nickname, responseClass, parameters, summary, notes);
+        return Objects.hashCode(httpMethod, nickname, responseClass, parameters, responseMessages, summary, notes);
     }
 
     @Override
@@ -78,6 +88,7 @@ public class Operation {
                 .add("nickname", nickname)
                 .add("responseClass", responseClass)
                 .add("parameters", parameters)
+                .add("responseMessages", responseMessages)
                 .add("summary", summary)
                 .add("notes", notes)
                 .toString();

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiMethodParser.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiMethodParser.java
@@ -61,11 +61,13 @@ public class ApiMethodParser {
         // response messages
         Pattern pattern = Pattern.compile("(\\d+) (.+)"); // matches "<code><space><text>"
         List<ApiResponseMessage> responseMessages = new LinkedList<ApiResponseMessage>();
-        for (Tag tag : methodDoc.tags("@errorResponse")) {
-            Matcher matcher = pattern.matcher(tag.text());
-            if (matcher.find()) {
-                responseMessages.add(new ApiResponseMessage(Integer.valueOf(matcher.group(1)),
-                        matcher.group(2)));
+        for (String tagName : options.getErrorTags()) {
+            for (Tag tagValue : methodDoc.tags(tagName)) {
+                Matcher matcher = pattern.matcher(tagValue.text());
+                if (matcher.find()) {
+                    responseMessages.add(new ApiResponseMessage(Integer.valueOf(matcher.group(1)),
+                            matcher.group(2)));
+                }
             }
         }
 

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiMethodParser.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiMethodParser.java
@@ -2,6 +2,7 @@ package com.hypnoticocelot.jaxrs.doclet.parser;
 
 import com.hypnoticocelot.jaxrs.doclet.DocletOptions;
 import com.hypnoticocelot.jaxrs.doclet.model.ApiParameter;
+import com.hypnoticocelot.jaxrs.doclet.model.ApiResponseMessage;
 import com.hypnoticocelot.jaxrs.doclet.model.HttpMethod;
 import com.hypnoticocelot.jaxrs.doclet.model.Method;
 import com.hypnoticocelot.jaxrs.doclet.model.Model;
@@ -9,6 +10,8 @@ import com.hypnoticocelot.jaxrs.doclet.translator.Translator;
 import com.sun.javadoc.*;
 
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.collect.Collections2.filter;
@@ -55,6 +58,17 @@ public class ApiMethodParser {
             ));
         }
 
+        // response messages
+        Pattern pattern = Pattern.compile("(\\d+) (.+)"); // matches "<code><space><text>"
+        List<ApiResponseMessage> responseMessages = new LinkedList<ApiResponseMessage>();
+        for (Tag tag : methodDoc.tags("@errorResponse")) {
+            Matcher matcher = pattern.matcher(tag.text());
+            if (matcher.find()) {
+                responseMessages.add(new ApiResponseMessage(Integer.valueOf(matcher.group(1)),
+                        matcher.group(2)));
+            }
+        }
+
         // return type
         Type type = methodDoc.returnType();
         String returnType = translator.typeName(type).value();
@@ -75,6 +89,7 @@ public class ApiMethodParser {
                 methodDoc.name(),
                 path,
                 parameters,
+                responseMessages,
                 firstSentences,
                 methodDoc.commentText().replace(firstSentences, ""),
                 returnType

--- a/jaxrs-doclet/src/test/resources/fixtures/sample/Service.java
+++ b/jaxrs-doclet/src/test/resources/fixtures/sample/Service.java
@@ -4,6 +4,10 @@ import javax.ws.rs.*;
 
 @Path("/foo")
 public class Service {
+    /**
+     * @errorResponse 404 not found
+     * @errorResponse ABC invalid code won't be parsed
+     */
     @GET
     public String sayHello(@QueryParam("name") @DefaultValue("World") String name) {
         return "Hello, " + name + "!";

--- a/jaxrs-doclet/src/test/resources/fixtures/sample/foo.json
+++ b/jaxrs-doclet/src/test/resources/fixtures/sample/foo.json
@@ -18,7 +18,13 @@
                             "name": "name",
                             "dataType": "string"
                         }
-                    ]
+                    ],
+                	"errorResponses": [
+                	    {
+                	        "code": 404,
+                	        "reason": "not found"
+                	    }
+                	]
                 },
                 {
                     "httpMethod": "POST",


### PR DESCRIPTION
Allows parsing of javadoc tag to feed "errorResponses" part of swagger api.

Syntax : `@[annotation_name] [code] [reason]`

Default tags :
- `@errorResponse` for swagger 1.1
- `@responseMessage` for swagger 1.2

Can be extended by providing custom tags with doclet parameter `-errorTags myTag1,myTag2,...`
