### PR TITLE
Treat select types as opaque on model generation.

### DIFF
--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/DocletOptions.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/DocletOptions.java
@@ -19,8 +19,9 @@ public class DocletOptions {
     private String docBasePath = "http://localhost:8080";
     private String apiBasePath = "http://localhost:8080";
     private String apiVersion = "0";
-    private List<String> excludeAnnotationClasses;
+    private List<String> typesToTreatAsOpaque;
     private List<String> errorTags;
+    private List<String> excludeAnnotationClasses;
     private boolean parseModels = true;
     private Recorder recorder = new ObjectMapperRecorder();
     private Translator translator;
@@ -32,6 +33,9 @@ public class DocletOptions {
         errorTags = new ArrayList<String>();
         errorTags.add("errorResponse");   // swagger 1.1
         errorTags.add("responseMessage"); // swagger 1.2
+        typesToTreatAsOpaque = new ArrayList<String>();
+        typesToTreatAsOpaque.add("org.joda.time.DateTime");
+        typesToTreatAsOpaque.add("java.util.UUID");
         translator = new FirstNotNullTranslator()
                 .addNext(new AnnotationAwareTranslator()
                         .ignore("javax.xml.bind.annotation.XmlTransient")
@@ -64,6 +68,8 @@ public class DocletOptions {
                 parsedOptions.parseModels = false;
             } else if (option[0].equals("-errorTags")) {
                 parsedOptions.errorTags.addAll(asList(copyOfRange(option, 1, option.length)));;
+            } else if (option[0].equals("-typesToTreatAsOpaque")) {
+                parsedOptions.typesToTreatAsOpaque.addAll(asList(copyOfRange(option, 1, option.length)));;
             }
         }
         return parsedOptions;
@@ -91,6 +97,10 @@ public class DocletOptions {
     
     public List<String> getErrorTags() {
         return errorTags;
+    }
+
+    public List<String> getTypesToTreatAsOpaque() {
+        return typesToTreatAsOpaque;
     }
 
     public boolean isParseModels() {

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiMethodParser.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiMethodParser.java
@@ -48,7 +48,7 @@ public class ApiMethodParser {
                 continue;
             }
             if (options.isParseModels()) {
-                models.addAll(new ApiModelParser(translator, parameter.type()).parse());
+                models.addAll(new ApiModelParser(options, translator, parameter.type()).parse());
             }
             parameters.add(new ApiParameter(
                     AnnotationHelper.paramTypeOf(parameter),
@@ -75,7 +75,7 @@ public class ApiMethodParser {
         Type type = methodDoc.returnType();
         String returnType = translator.typeName(type).value();
         if (options.isParseModels()) {
-            models.addAll(new ApiModelParser(translator, type).parse());
+            models.addAll(new ApiModelParser(options, translator, type).parse());
         }
 
         // First Sentence of Javadoc method description

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiModelParser.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiModelParser.java
@@ -1,6 +1,8 @@
 package com.hypnoticocelot.jaxrs.doclet.parser;
 
 import com.google.common.base.Predicate;
+
+import com.hypnoticocelot.jaxrs.doclet.DocletOptions;
 import com.hypnoticocelot.jaxrs.doclet.model.Model;
 import com.hypnoticocelot.jaxrs.doclet.model.Property;
 import com.hypnoticocelot.jaxrs.doclet.translator.Translator;
@@ -12,11 +14,13 @@ import static com.google.common.collect.Collections2.filter;
 
 public class ApiModelParser {
 
+    private final DocletOptions options;
     private final Translator translator;
     private final Type rootType;
     private final Set<Model> models;
 
-    public ApiModelParser(Translator translator, Type rootType) {
+    public ApiModelParser(DocletOptions options, Translator translator, Type rootType) {
+        this.options = options;
         this.translator = translator;
         this.rootType = rootType;
         this.models = new LinkedHashSet<Model>();
@@ -31,8 +35,9 @@ public class ApiModelParser {
         boolean isPrimitive = /* type.isPrimitive()? || */ AnnotationHelper.isPrimitive(type);
         boolean isJavaxType = type.qualifiedTypeName().startsWith("javax.");
         boolean isBaseObject = type.qualifiedTypeName().equals("java.lang.Object");
+        boolean isTypeToTreatAsOpaque = options.getTypesToTreatAsOpaque().contains(type.qualifiedTypeName());
         ClassDoc classDoc = type.asClassDoc();
-        if (isPrimitive || isJavaxType || isBaseObject || classDoc == null || alreadyStoredType(type)) {
+        if (isPrimitive || isJavaxType || isBaseObject || isTypeToTreatAsOpaque || classDoc == null || alreadyStoredType(type)) {
             return;
         }
 


### PR DESCRIPTION
Added option to treat certain types as opaque and not generate models for.
Currently it defaults to java.util.UUID & org.joda.time.DateTime, other types can be added via the typesToTreatAsOpaque option (it's a list).
