### PR TITLE
Change example dependency to 0.0.3-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use the Swagger Doclet in your Maven project, add the following to your POM f
                             <docletArtifact>
                                 <groupId>com.hypnoticocelot</groupId>
                                 <artifactId>jaxrs-doclet</artifactId>
-                                <version>0.0.2-SNAPSHOT</version>
+                                <version>0.0.3-SNAPSHOT</version>
                             </docletArtifact>
                             <reportOutputDirectory>${project.build.outputDirectory}</reportOutputDirectory>
                             <useStandardDocletOptions>false</useStandardDocletOptions>


### PR DESCRIPTION
0.0.2-SNAPSHOT gives a 404 on OSS Sonatype.
