### PR TITLE
Update dropwizard sample version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ An example project using Dropwizard is included in `jaxrs-doclet-sample-dropwiza
 ```
 $ cd jaxrs-doclet-sample-dropwizard
 $ mvn package
-$ java -jar target/jaxrs-doclet-sample-dropwizard target/jaxrs-doclet-sample-dropwizard-0.0.2-SNAPSHOT.jar sample.yml
+$ java -jar target/jaxrs-doclet-sample-dropwizard target/jaxrs-doclet-sample-dropwizard-0.0.3-SNAPSHOT.jar sample.yml
 ```
 
 The example server should be running on port 8080:


### PR DESCRIPTION
It's building v0.0.3-SNAPSHOT, not v0.0.2-SNAPSHOT
