### PR TITLE
REST method return type overriding (solves not generating models for javax.ws.rs.core.Response)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,24 @@ To override the swagger ui included with the doclet, create your own swagger-ui.
 ```
 <additionalparam>-apiVersion 1 -docBasePath /apidocs -apiBasePath / -swaggerUiZipPath ../../../src/main/resources/swagger-ui.zip</additionalparam>
 ```
+
+## Override Model type returned by the REST method
+
+If the REST method returns e.g. `javax.ws.rs.core.Response` wrapping the real response type and the model is not generated, it is possible to override the type that should be used for model generation in a dedicated conf file. 
+It's a standard java properties file with mappings:
+
+    qualified method name=java type that should be used for model generation
+
+e.g.
+
+    fixtures.sample.Service.getSubResourceWrappedInResponse(java.lang.String,java.util.List<fixtures.sample.model.SomeClass>)=fixtures.sample.SubResource
+    fixtures.sample.Service.otherMethod()=fixtures.sample.SomeOtherClass
+
+Please notice there are NO white characters.
+The classes used for overriding MUST belong to the sources processed by this tool.
+
+To activate this feature, `-returnTypesOverrideMapping` doclet option has to be used:
+
+```
+<additionalparam>-apiVersion 1 -docBasePath /apidocs -apiBasePath / -returnTypesOverrideMapping PATH_TO_CONF_FILE/CONF_FILE.properties</additionalparam>
+```

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/ServiceDoclet.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/ServiceDoclet.java
@@ -43,6 +43,7 @@ public class ServiceDoclet {
         options.put("-excludeAnnotationClasses", 2);
         options.put("-disableModels", 1);
         options.put("-errorTags", 2);
+        options.put("-returnTypesOverrideMapping", 2);
 
         Integer value = options.get(option);
         if (value != null) {

--- a/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiClassParser.java
+++ b/jaxrs-doclet/src/main/java/com/hypnoticocelot/jaxrs/doclet/parser/ApiClassParser.java
@@ -57,8 +57,8 @@ public class ApiClassParser {
 
         for (MethodDoc method : classDoc.methods()) {
             ApiMethodParser methodParser = parentMethod == null ?
-                    new ApiMethodParser(options, rootPath, method) :
-                    new ApiMethodParser(options, parentMethod, method);
+                    new ApiMethodParser(options, rootPath, classes, method) :
+                    new ApiMethodParser(options, parentMethod, classes, method);
             Method parsedMethod = methodParser.parse();
             if (parsedMethod == null) {
                 continue;

--- a/jaxrs-doclet/src/test/java/com/hypnoticocelot/jaxrs/doclet/apidocs/ServiceDocletTest.java
+++ b/jaxrs-doclet/src/test/java/com/hypnoticocelot/jaxrs/doclet/apidocs/ServiceDocletTest.java
@@ -44,5 +44,27 @@ public class ServiceDocletTest {
         final ApiDeclaration expectedDeclaration = loadFixture("/fixtures/sample/foo.json", ApiDeclaration.class);
         verify(recorderMock).record(any(File.class), eq(expectedDeclaration));
     }
+    
+    @Test
+    public void testStartWithReturnTypeOverriden() throws IOException {
+        // given
+        String[][] opts = {{"-returnTypesOverrideMapping", "src/test/resources/fixtures/sample/returnTypeMapping.properties"}};
+        options = DocletOptions.parse(opts);
+        options.setRecorder(recorderMock);
+        
+        final RootDoc rootDoc = RootDocLoader.fromPath("src/test/resources", "fixtures.sample");
+        
+        //when
+        boolean parsingResult = new JaxRsAnnotationParser(options, rootDoc).run();
+        
+        //then
+        assertThat("JavaDoc generation failed", parsingResult, equalTo(true));
+
+        final ResourceListing expectedListing = loadFixture("/fixtures/sample/service.json", ResourceListing.class);
+        verify(recorderMock).record(any(File.class), eq(expectedListing));
+
+        final ApiDeclaration expectedDeclaration = loadFixture("/fixtures/sample/foo_returnTypeOverriden.json", ApiDeclaration.class);
+        verify(recorderMock).record(any(File.class), eq(expectedDeclaration));
+    }
 
 }

--- a/jaxrs-doclet/src/test/resources/fixtures/sample/Service.java
+++ b/jaxrs-doclet/src/test/resources/fixtures/sample/Service.java
@@ -1,6 +1,7 @@
 package fixtures.sample;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 
 @Path("/foo")
 public class Service {
@@ -27,5 +28,11 @@ public class Service {
     @Path("{fooId}/sub")
     public SubResource getSubResource(@PathParam("fooId") String fooId) {
         return new SubResource();
+    }
+    
+    @Path("/jaxrsresponse")
+    @GET
+    public Response getSubResourceWrappedInResponse(@QueryParam("pameter1") @DefaultValue("pameter1") String pameter1, @QueryParam("pameter2") String pameter2) {
+       return Response.ok(new SubResource()).build();
     }
 }

--- a/jaxrs-doclet/src/test/resources/fixtures/sample/foo.json
+++ b/jaxrs-doclet/src/test/resources/fixtures/sample/foo.json
@@ -59,6 +59,26 @@
             ]
         },
         {
+            "path": "/foo/jaxrsresponse",
+            "description": "",
+            "operations": [
+                {
+                    "httpMethod": "GET",
+                    "nickname": "getSubResourceWrappedInResponse",
+                    "responseClass": "Response",
+                    "parameters" : [ {
+                        "paramType" : "query",
+                        "name" : "pameter1",
+                        "dataType" : "string"
+                      }, {
+                        "paramType" : "query",
+                        "name" : "pameter2",
+                        "dataType" : "string"
+                      } ]
+                }
+            ]
+        },
+        {
             "path": "/foo/{fooId}/sub",
             "description": "",
             "operations": [

--- a/jaxrs-doclet/src/test/resources/fixtures/sample/foo_returnTypeOverriden.json
+++ b/jaxrs-doclet/src/test/resources/fixtures/sample/foo_returnTypeOverriden.json
@@ -1,0 +1,124 @@
+{
+    "apiVersion": "0",
+    "swaggerVersion": "1.1",
+    "basePath": "http://localhost:8080",
+    "resourcePath": "/foo",
+    "apis": [
+        {
+            "path": "/foo",
+            "description": "",
+            "operations": [
+                {
+                    "httpMethod": "GET",
+                    "nickname": "sayHello",
+                    "responseClass": "string",
+                    "parameters": [
+                        {
+                            "paramType": "query",
+                            "name": "name",
+                            "dataType": "string"
+                        }
+                    ],
+                    "errorResponses": [
+                        {
+                            "code": 404,
+                            "reason": "not found"
+                        }
+                    ]
+                },
+                {
+                    "httpMethod": "POST",
+                    "nickname": "createSpeech",
+                    "responseClass": "int",
+                    "parameters": [
+                        {
+                            "paramType": "body",
+                            "name": "speech",
+                            "dataType": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "/foo/annotated",
+            "description": "",
+            "operations": [
+                {
+                    "httpMethod": "POST",
+                    "nickname": "createSpeechWithAnnotatedPayload",
+                    "responseClass": "int",
+                    "parameters": [
+                        {
+                            "paramType": "body",
+                            "name": "speech",
+                            "dataType": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "/foo/jaxrsresponse",
+            "description": "",
+            "operations": [
+                {
+                    "httpMethod": "GET",
+                    "nickname": "getSubResourceWrappedInResponse",
+                    "responseClass": "SubResource",
+                    "parameters" : [ {
+                        "paramType" : "query",
+                        "name" : "pameter1",
+                        "dataType" : "string"
+                      }, {
+                        "paramType" : "query",
+                        "name" : "pameter2",
+                        "dataType" : "string"
+                      } ]
+                }
+            ]
+        },
+        {
+            "path": "/foo/{fooId}/sub",
+            "description": "",
+            "operations": [
+                {
+                    "httpMethod": "POST",
+                    "nickname": "createSub",
+                    "responseClass": "int",
+                    "parameters": [
+
+                        {
+                            "paramType": "path",
+                            "name": "fooId",
+                            "dataType": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "/foo/{fooId}/sub/annotated",
+            "description": "",
+            "operations": [
+                {
+                    "httpMethod": "GET",
+                    "nickname": "sayHello",
+                    "responseClass": "string",
+                    "parameters": [
+                        {
+                            "paramType": "query",
+                            "name": "name",
+                            "dataType": "string"
+                        },
+                        {
+                            "paramType": "path",
+                            "name": "fooId",
+                            "dataType": "string"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/jaxrs-doclet/src/test/resources/fixtures/sample/returnTypeMapping.properties
+++ b/jaxrs-doclet/src/test/resources/fixtures/sample/returnTypeMapping.properties
@@ -1,0 +1,1 @@
+fixtures.sample.Service.getSubResourceWrappedInResponse(java.lang.String,java.lang.String)=fixtures.sample.SubResource


### PR DESCRIPTION
## Problem

This change addresses a problem where there's no model information generated if the return type of a REST method is wrapped inside javax.ws.rs.core.Response object (often the case). 
http://docs.oracle.com/javaee/7/api/javax/ws/rs/core/Response.html
## Current situation

Currently model generation from javax.ws.rs.core.Response is not supported at all because packages starting with "javax." are excluded from model documentation by this tool. Even if it wasn't excluded, it's impossible to find out which object is wrapped by javax.ws.rs.core.Response since its type is not known at compilation time - it's kept as Object

http://docs.oracle.com/javaee/7/api/javax/ws/rs/core/Response.html#ok(java.lang.Object)
## Proposed solution

An additional, optional doclet parameter, that points to a conf file (standard java properties file) with mapping:
  qualified method name -> java type that should be used for model generation

e.g. 
    fixtures.sample.Service.getSubResourceWrappedInResponse(java.lang.String,java.lang.String)=fixtures.sample.SubResource
## Other solutions

Instead of using a mapping in a separate configuration file, it is be possible to use an annotation (an approach used by enunciate project: @org.codehaus.enunciate.jaxrs.TypeHint)
In this approach however, non-standard annotations have to be added to the code. 
